### PR TITLE
Add multiple admins feature

### DIFF
--- a/src/tazer.py
+++ b/src/tazer.py
@@ -22,7 +22,7 @@ GUILDS_CONNECTED = {}
 DEFAULT_CATEGORY_NAME = 'Discussion Rooms'
 
 VOICE_CHANNEL_STR = 'voice_channel'
-HOST_STR = 'host'
+ADMINS_STR = 'admins'
 ROLE_STR = 'role'
 TXT_CHANNEL_STR = 'text_channel'
 CATEGORY_STR = 'catagory'
@@ -131,7 +131,7 @@ async def create_discussion_room(ctx, room_name):
             await member.add_roles(role)
         
         GUILDS_CONNECTED[guild.id][ROOMS_STR][p_text_channel] = {
-            HOST_STR: ctx.author,
+            ADMINS_STR: [ctx.author],
             ROLE_STR: role,
             TXT_CHANNEL_STR: p_text_channel,
             VOICE_CHANNEL_STR: p_voice_channel
@@ -158,9 +158,9 @@ async def remove_members(ctx):
 
     assert ctx.message.author in text_channel.members
 
-    room_host = all_rooms_created[text_channel][HOST_STR]
+    room_admins = all_rooms_created[text_channel][ADMINS_STR]
 
-    assert ctx.author == room_host, f'Only the host, {room_host} can remove people from this discussion room!'
+    assert ctx.author in room_admins, f'Only admins can remove people from this discussion room!'
 
     role = all_rooms_created[text_channel][ROLE_STR]
 
@@ -229,6 +229,47 @@ async def create_poll(ctx, question, *options):
         await bot_msg.add_reaction(emoji)
 
 
+@bot.command(name='assign', help='Assign @members admin of the discussion room')
+async def assign_admin(ctx):
+    await ctx.message.delete()
+
+    guild = ctx.guild
+    all_rooms_created = GUILDS_CONNECTED[guild.id][ROOMS_STR]
+    room = ctx.channel
+
+    # To make sure command can only be invoked in discussion_rooms created by the bot
+    if room not in all_rooms_created:
+        return
+    
+    room_properties = GUILDS_CONNECTED[guild.id][ROOMS_STR][room]
+    room_admins = room_properties[ADMINS_STR]
+    role_to_be_assigned = room_properties[ROLE_STR]
+
+    if ctx.author in room_admins:
+        for member_to_be_admin in ctx.message.mentions:
+            # To avoid duplicates in room_admins list
+            # assumed only members in the discussion_room can be mentioned
+            if member_to_be_admin not in room_admins:
+                room_admins.append(member_to_be_admin)
+                await room.send(f'{member_to_be_admin.mention} is now an admin of {room.name}!')
+    else:
+        await room.send('Only admins of this discussion room can assign admins!')
+
+
+''' ************************ TBD WHETHER TO ADD *******************************
+@bot.command(name='admins', help='Assign @users admin of the discussion room')
+async def admins_list(ctx):
+    guild = ctx.guild
+    room = ctx.channel
+    room_properties = GUILDS_CONNECTED[guild.id][ROOMS_STR][room]
+
+    room_admins = room_properties[ADMINS_STR]
+
+    for admin in room_admins:
+        await room.send(admin.mention)
+'''
+
+
 @bot.command(name='end', help='Deletes the discussion room')
 async def delete_discussion_room(ctx):
     await ctx.message.delete()
@@ -242,10 +283,10 @@ async def delete_discussion_room(ctx):
     # to make sure t! end is initiated in a room created by the bot
     assert text_channel in all_rooms_created
 
-    room_host = all_rooms_created[text_channel][HOST_STR]
+    room_admins = all_rooms_created[text_channel][ADMINS_STR]
 
     # assertations
-    assert ctx.author == room_host, f'Only the host, {room_host} can end this discussion room!'
+    assert ctx.author in room_admins, f'Only admins can end this discussion room!'
 
     voice_channel = all_rooms_created[text_channel][VOICE_CHANNEL_STR]
     role = all_rooms_created[text_channel][ROLE_STR]


### PR DESCRIPTION
Only admins of a discussion_room can remove people from the room and end the discussion_room

To be discussed: Should the t! end command be available to the creator of the discussion_room ONLY or the admins?